### PR TITLE
use transparent background for pre. fixes #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,8 @@ function updateOutputArea() {
       .addClass('prettyprint')
       .css({
         'font-size': `${config.typeSize}px`,
-        'line-height': `${config.typeSize * 1.5}px`
+        'line-height': `${config.typeSize * 1.5}px`,
+        'background' : 'transparent'
       })
       .text(cleanupCode(config.code))
       .appendTo($output);

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function updateOutputArea() {
       .css({
         'font-size': `${config.typeSize}px`,
         'line-height': `${config.typeSize * 1.5}px`,
-        'background' : 'transparent'
+        'background': 'transparent'
       })
       .text(cleanupCode(config.code))
       .appendTo($output);


### PR DESCRIPTION
didn't really test on other browsers. works from chrome but does not work from safari (both to keynote).
feel free to ignore the PR.