### PR TITLE
Added Rust to the language list

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
             <option value="lua">Lua</option>
             <option value="python">Python</option>
             <option value="ruby">Ruby</option>
+            <option value="rust">Rust</option>
             <option value="sql">SQL</option>
             <option value="xml">XML</option>
             <option value="yaml">Yaml</option>


### PR DESCRIPTION
The current version of prettify-laguages.js already contains support for Rust. It also works in auto-detection. But it would be nice to add it to the list so Rusticians know it's supported :) 
![_085](https://user-images.githubusercontent.com/3250983/42535704-622d8df2-8490-11e8-949b-a87ebb14f0f7.png)
