### PR TITLE
Add Clojure to the select of languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
           <select id="lang">
             <option value="--">(auto detect language)</option>
             <option value="c++">C++</option>
+            <option value="clj">Clojure</option>
             <option value="css">CSS</option>
             <option value="dart">Dart</option>
             <option value="go">Go</option>


### PR DESCRIPTION
Hello!

Auto detect is not highlighting keywords properly in Clojure, so I added it to the select of the interface. It's a just a one liner.

![](https://i.imgur.com/yS7RfXM.png)

![](https://i.imgur.com/x2RPZSW.png)