### PR TITLE
Add Angular Material Color theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
             <option value="io17">#io17</option>
             <option value="io19">#io19</option>
             <option value="flutter-interact-19">Flutter Interact 2019</option>
+            <option value="angular-material">Angular Material</option>
             <option value="custom">Custom</option>
           </select>
         </div>

--- a/themes.js
+++ b/themes.js
@@ -239,5 +239,19 @@ export const DEFAULT_THEMES = {
     dimmedColor: "#87858e",
     highlightColor: '#425a6c',
     lineHeight: 1.2,
+  },
+  'angular-material': {
+    bgColor: "#382e42",
+    textColor: "#ffffff",
+    punctuationColor: materialColor('light-blue', '100'),
+    stringAndValueColor: "#c3e88d",
+    keywordTagColor: materialColor('light-blue', '100'),
+    commentColor: materialColor('grey', '500'),
+    typeColor: materialColor('orange', '200'),
+    numberColor: materialColor('purple', '200'),
+    declarationColor: materialColor('purple', '200'),
+    dimmedColor: "#4d4d4d",
+    highlightColor: "#4d3663",
+    lineHeight: 1.2
   }
 };


### PR DESCRIPTION
Add an Angular Material color theme for formatting code for decks following the styling of Angular Material.

This custom theme is currently used for all external slides by the Angular team at Google - so having a drop down option would be super helpful!