### PR TITLE
fix selecting text with carriage returns

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ function highlightSelection() {
   let {code, commonIndent, leadingEmptyLines} = cleanupCode(rawCode);
   let preRoot = $output.find('pre').get(0);
 
-  let rangeToCharPos = ({row, column}) => code.split(/\n/)
+  let rangeToCharPos = ({row, column}) => code.split(/\r?\n/)
       .slice(0, row - leadingEmptyLines)
       .reduce((a, r) => a + r.length + 1, 0)
       + Math.max(0,


### PR DESCRIPTION
Previously, if the pasted code contained carriage returns, the character position calculation would be incorrect, causing the wrong code to be highlighted.